### PR TITLE
Fix deprecation warnings: replace callf with cl-callf for Emacs 27.1+ compatibility

### DIFF
--- a/ert-tests/persistent-soft-a-test.el
+++ b/ert-tests/persistent-soft-a-test.el
@@ -128,7 +128,7 @@
 
 (ert-deftest persistent-soft-a:g-data-types-02 nil
   (let ((value "string with properties"))
-    (callf propertize value :face 'bold)
+    (cl-callf propertize value :face 'bold)
     (should
      (persistent-soft-store 'string-with-properties-key value "ert-test-persistent-soft-location-1"))
     (should

--- a/ert-tests/persistent-soft-b-test.el
+++ b/ert-tests/persistent-soft-b-test.el
@@ -55,7 +55,7 @@
 
 (ert-deftest persistent-soft-b:c-data-types-02 nil
   (let ((value "string with properties"))
-    (callf propertize value :face 'bold)
+    (cl-callf propertize value :face 'bold)
     (should
      (persistent-soft-exists-p 'string-with-properties-key "ert-test-persistent-soft-location-1"))
     (should (equal-including-properties value

--- a/persistent-soft.el
+++ b/persistent-soft.el
@@ -373,8 +373,8 @@ Returns a true value if storage was successful.  Returns nil
 on failure, without throwing an error."
   (when (and (featurep 'pcache)
              (stringp location))
-    (callf or expiration (round (* 60 60 24 persistent-soft-default-expiration-days)))
-    (callf persistent-soft--sanitize-data value)
+    (cl-callf or expiration (round (* 60 60 24 persistent-soft-default-expiration-days)))
+    (cl-callf persistent-soft--sanitize-data value)
     (let ((repo (ignore-errors
                   (persistent-soft--with-suppressed-messages
                     (pcache-repository location))))


### PR DESCRIPTION
## Fix deprecation warnings for Emacs 27.1+

This PR replaces the deprecated `callf` with `cl-callf` to fix compatibility with modern Emacs versions.

### Changes:
- **persistent-soft.el**: Replace `callf` with `cl-callf` in `persistent-soft-store` function
- **ert-tests/persistent-soft-a-test.el**: Replace `callf` with `cl-callf` in test
- **ert-tests/persistent-soft-b-test.el**: Replace `callf` with `cl-callf` in test

### Why:
- `callf` has been obsolete since Emacs 27.1
- `cl-callf` is the modern replacement from the `cl-lib` package
- This eliminates deprecation warnings in Emacs 27.1+

### Testing:
- ✅ Package loads successfully without deprecation warnings
- ✅ All functionality preserved
- ✅ Test files updated for consistency

This fix ensures persistent-soft continues to work seamlessly with modern Emacs versions while eliminating deprecation warnings.